### PR TITLE
Avoid UNICODE_CHARACTER_CLASS flag for date parsing regex

### DIFF
--- a/java/src/main/java/io/rapidpro/expressions/dates/DateParser.java
+++ b/java/src/main/java/io/rapidpro/expressions/dates/DateParser.java
@@ -124,7 +124,7 @@ public class DateParser {
         }
 
         // split the text into numerical and text tokens
-        Pattern pattern = Pattern.compile("([0-9]+|[^\\W\\d]+)", Pattern.UNICODE_CHARACTER_CLASS);
+        Pattern pattern = Pattern.compile("([0-9]+|\\p{L}+)");
         Matcher matcher = pattern.matcher(text);
         List<String> tokens = new ArrayList<>();
         while (matcher.find()) {


### PR DESCRIPTION
I think this is a reasonable proxy for Android regexes which don't support the flag Pattern.UNICODE_CHARACTER_CLASS. This is blocking the "is a date" rule from working on Surveyor. 