### PR TITLE
Fix date v datetime comparisons

### DIFF
--- a/java/src/main/java/io/rapidpro/expressions/evaluator/Conversions.java
+++ b/java/src/main/java/io/rapidpro/expressions/evaluator/Conversions.java
@@ -225,7 +225,14 @@ public class Conversions {
 
         try {
             // try converting to two dates
-            return new ImmutablePair<Object, Object>(toDateOrDateTime(value1, ctx), toDateOrDateTime(value2, ctx));
+            Temporal d1 = toDateOrDateTime(value1, ctx);
+            Temporal d2 = toDateOrDateTime(value2, ctx);
+            if (!value1.getClass().equals(value2.getClass())) {
+                d1 = toDateTime(d1, ctx);
+                d2 = toDateTime(d2, ctx);
+            }
+
+            return new ImmutablePair<Object, Object>(d1, d2);
         }
         catch (EvaluationError ex) {}
 

--- a/java/src/test/java/io/rapidpro/expressions/evaluator/EvaluatorTest.java
+++ b/java/src/test/java/io/rapidpro/expressions/evaluator/EvaluatorTest.java
@@ -48,6 +48,8 @@ public class EvaluatorTest {
         EvaluationContext context = new EvaluationContext();
         context.putVariable("foo", 5);
         context.putVariable("bar", 3);
+        context.putVariable("now", "17-02-2017 15:10");
+        context.putVariable("today", "17-02-2017");
         
         assertThat(m_evaluator.evaluateExpression("true", context), is((Object) true));
         assertThat(m_evaluator.evaluateExpression("FALSE", context), is((Object) false));
@@ -89,6 +91,12 @@ public class EvaluatorTest {
         assertThat(m_evaluator.evaluateExpression("FIXED(1234.5678)", context), is((Object) "1,234.57"));
         assertThat(m_evaluator.evaluateExpression("FIXED(1234.5678, 1)", context), is((Object) "1,234.6"));
         assertThat(m_evaluator.evaluateExpression("FIXED(1234.5678, 1, True)", context), is((Object) "1234.6"));
+
+        // check comparisons
+        assertThat(m_evaluator.evaluateExpression("foo > bar", context), is((Object) true));
+        assertThat(m_evaluator.evaluateExpression("foo < bar", context), is((Object) false));
+        assertThat(m_evaluator.evaluateExpression("now > (today - 1)", context), is((Object) true));
+        assertThat(m_evaluator.evaluateExpression("now < (today - 1)", context), is((Object) false));
     }
 
     @Test

--- a/python/temba_expressions/conversions.py
+++ b/python/temba_expressions/conversions.py
@@ -174,7 +174,12 @@ def to_same(value1, value2, ctx):
 
     try:
         # try converting to two dates
-        return to_date_or_datetime(value1, ctx), to_date_or_datetime(value2, ctx)
+        d1, d2 = to_date_or_datetime(value1, ctx), to_date_or_datetime(value2, ctx)
+
+        # if either one is a datetime, then the other needs to become a datetime
+        if type(value1) != type(value2):
+            d1, d2 = to_datetime(d1, ctx), to_datetime(d2, ctx)
+        return d1, d2
     except EvaluationError:
         pass
 

--- a/python/temba_expressions/tests.py
+++ b/python/temba_expressions/tests.py
@@ -300,6 +300,8 @@ class EvaluatorTest(unittest.TestCase):
         context = EvaluationContext()
         context.put_variable("foo", 5)
         context.put_variable("bar", 3)
+        context.put_variable("now", "17-02-2017 15:10")
+        context.put_variable("today", "17-02-2017")
 
         self.assertEqual(self.evaluator.evaluate_expression("true", context), True)
         self.assertEqual(self.evaluator.evaluate_expression("FALSE", context), False)
@@ -341,6 +343,12 @@ class EvaluatorTest(unittest.TestCase):
         self.assertEqual(self.evaluator.evaluate_expression("FIXED(1234.5678)", context), "1,234.57")
         self.assertEqual(self.evaluator.evaluate_expression("FIXED(1234.5678, 1)", context), "1,234.6")
         self.assertEqual(self.evaluator.evaluate_expression("FIXED(1234.5678, 1, True)", context), "1234.6")
+
+        # check comparisons
+        self.assertEqual(self.evaluator.evaluate_expression("foo > bar", context), True)
+        self.assertEqual(self.evaluator.evaluate_expression("foo < bar", context), False)
+        self.assertEqual(self.evaluator.evaluate_expression("now > (today - 1)", context), True)
+        self.assertEqual(self.evaluator.evaluate_expression("now < (today - 1)", context), False)
 
         
 class FunctionsTest(unittest.TestCase):


### PR DESCRIPTION
Currently these blow up as they aren't the same type https://sentry.io/nyaruka/textit/issues/219466826/

PR fixes `conversions.to_same` so that if either value is a datetime, they are both converted to datetime.