### PR TITLE
Add format_location to expressions library

### DIFF
--- a/java/src/main/java/io/rapidpro/expressions/functions/CustomFunctions.java
+++ b/java/src/main/java/io/rapidpro/expressions/functions/CustomFunctions.java
@@ -155,6 +155,15 @@ public class CustomFunctions {
         return ctx.getDateFormatter(true).format(_dt);
     }
 
+    /**
+     * Takes a single parameter (administrative boundary as a string) and returns the name of the leaf boundary
+     */
+    public static String format_location(EvaluationContext ctx, Object text) {
+        String _text = Conversions.toString(text, ctx);
+        String[] splits = _text.split(">");
+        return splits[splits.length - 1].trim();
+    }
+
     /************************************************************************************
      * Helper (not available in expressions)
      ************************************************************************************/

--- a/java/src/test/java/io/rapidpro/expressions/functions/CustomFunctionsTest.java
+++ b/java/src/test/java/io/rapidpro/expressions/functions/CustomFunctionsTest.java
@@ -135,6 +135,13 @@ public class CustomFunctionsTest {
         } catch (EvaluationError e){}
     }
 
+    public void test_format_location() {
+        EvaluationContext context = new EvaluationContext(new HashMap<String,Object>(), ZoneId.of("Africa/Kigali"), DateStyle.DAY_FIRST);
+        assertThat(format_location(context, "Rwanda > Kigali > Kimihurura"), is("Kimihurura"));
+        assertThat(format_location(context, "Rwanda > Kigali"), is("Kigali"));
+        assertThat(format_location(context, "Rwanda"), is("Rwanda"));
+    }
+
     @Test(expected = RuntimeException.class)
     public void test_word_slice_zeroStart() {
         word_slice(m_context, " abc  def ghi-jkl ", 0, 0, false);  // start can't be zero

--- a/python/temba_expressions/functions/custom.py
+++ b/python/temba_expressions/functions/custom.py
@@ -139,6 +139,13 @@ def format_date(ctx, text):
     return dt.astimezone(ctx.timezone).strftime(ctx.get_date_format(True))
 
 
+def format_location(ctx, text):
+    """
+    Takes a single parameter (administrative boundary as a string) and returns the name of the leaf boundary
+    """
+    return text.split(">")[-1].strip()
+
+
 #################################### Helper (not available in expressions) ####################################
 
 def __get_words(text, by_spaces):

--- a/python/temba_expressions/tests.py
+++ b/python/temba_expressions/tests.py
@@ -675,6 +675,10 @@ class FunctionsTest(unittest.TestCase):
         self.assertEqual("01-02-2034 16:55", custom.format_date(self.context, "01-02-2034 16:55"))
         self.assertRaises(EvaluationError, custom.format_date, self.context, 'not date')
 
+        self.assertEqual("Kimihurura", custom.format_location(self.context, "Rwanda > Kigali > Kimihurura"))
+        self.assertEqual("Kigali", custom.format_location(self.context, "Rwanda > Kigali"))
+        self.assertEqual("Rwanda", custom.format_location(self.context, "Rwanda"))
+
 
 class TemplateTest(unittest.TestCase):
 


### PR DESCRIPTION
Basically the equivalent of `format_date` but for formatted locations.