### PR TITLE
Add EPOCH() function and tweak math ops to be closer to new world 

### DIFF
--- a/common/template_tests.json
+++ b/common/template_tests.json
@@ -89,7 +89,7 @@
     "template": "@(100 / 3) @(2 * 100 / 3)",
     "context": {"variables": {}, "timezone": "UTC", "date_style": "day_first"},
     "url_encode": false,
-    "output": "33.33333333 66.66666667",
+    "output": "33.33333333333333333333333333 66.66666666666666666666666667",
     "errors": []
   },
 
@@ -301,7 +301,7 @@
     "template": "@(EXP(2))",
     "context": {"variables": {}, "timezone": "UTC", "date_style": "day_first"},
     "url_encode": false,
-    "output": "7.389056099",
+    "output": "7.389056098930649518763402739",
     "errors": []
   },
   {
@@ -592,10 +592,10 @@
     "errors": []
   },
   {
-    "template": "@(TO_EPOCH(d1)) @(TO_EPOCH(d2)) @(TO_EPOCH(d2) / 1000000000)",
+    "template": "@(EPOCH(d1)) @(EPOCH(d2)) @(INT(EPOCH(d1)))",
     "context": {"variables": {"d1": "2017-06-12T16:56:59.123456Z", "d2": "2017-06-12T18:56:59.000000+02:00"}, "timezone": "UTC", "date_style": "day_first"},
     "url_encode": false,
-    "output": "1497286619123456000 1497286619000000000 1497286619",
+    "output": "1497286619.123456 1497286619 1497286619",
     "errors": []
   },
   {

--- a/common/template_tests.json
+++ b/common/template_tests.json
@@ -592,6 +592,13 @@
     "errors": []
   },
   {
+    "template": "@(TO_EPOCH(d1)) @(TO_EPOCH(d2)) @(TO_EPOCH(d2) / 1000000000)",
+    "context": {"variables": {"d1": "2017-06-12T16:56:59.123456Z", "d2": "2017-06-12T18:56:59.000000+02:00"}, "timezone": "UTC", "date_style": "day_first"},
+    "url_encode": false,
+    "output": "1497286619123456000 1497286619000000000 1497286619",
+    "errors": []
+  },
+  {
     "template": "@(TRUE())",
     "context": {"variables": {}, "timezone": "UTC", "date_style": "day_first"},
     "url_encode": false,

--- a/java/src/main/java/io/rapidpro/expressions/evaluator/Conversions.java
+++ b/java/src/main/java/io/rapidpro/expressions/evaluator/Conversions.java
@@ -256,15 +256,11 @@ public class Conversions {
     }
 
     /**
-     * Formats a decimal number using the same precision as Excel
+     * Formats a decimal number
      * @param decimal the decimal value
      * @return the formatted string value
      */
     private static String formatDecimal(BigDecimal decimal) {
-        decimal = decimal.stripTrailingZeros();
-        int intDigits = decimal.precision() - decimal.scale();  // number of non-fractional digits
-        int fractionalDigits = Math.min(Math.max(10 - intDigits, 0), decimal.scale());
-        decimal = decimal.setScale(fractionalDigits, RoundingMode.HALF_UP);
-        return decimal.toPlainString();
+        return decimal.stripTrailingZeros().toPlainString();
     }
 }

--- a/java/src/main/java/io/rapidpro/expressions/evaluator/ExpressionVisitorImpl.java
+++ b/java/src/main/java/io/rapidpro/expressions/evaluator/ExpressionVisitorImpl.java
@@ -15,6 +15,7 @@ import org.threeten.bp.temporal.Temporal;
 import org.threeten.bp.temporal.TemporalAmount;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -97,7 +98,7 @@ public class ExpressionVisitorImpl extends ExcellentBaseVisitor<Object> {
             throw new EvaluationError("Division by zero");
         }
 
-        return multiplication ? arg1.multiply(arg2) : arg1.divide(arg2, 10, RoundingMode.HALF_UP);
+        return multiplication ? arg1.multiply(arg2, ExpressionUtils.MATH) : arg1.divide(arg2, ExpressionUtils.MATH);
     }
 
     /**
@@ -113,7 +114,7 @@ public class ExpressionVisitorImpl extends ExcellentBaseVisitor<Object> {
         try {
             BigDecimal _arg1 = Conversions.toDecimal(arg1, m_evalContext);
             BigDecimal _arg2 = Conversions.toDecimal(arg2, m_evalContext);
-            return add ? _arg1.add(_arg2) : _arg1.subtract(_arg2);
+            return add ? _arg1.add(_arg2, ExpressionUtils.MATH) : _arg1.subtract(_arg2, ExpressionUtils.MATH);
         } catch (EvaluationError ignored) {}
 
         // then as date + something

--- a/java/src/main/java/io/rapidpro/expressions/functions/CustomFunctions.java
+++ b/java/src/main/java/io/rapidpro/expressions/functions/CustomFunctions.java
@@ -60,9 +60,10 @@ public class CustomFunctions {
     /**
      * Converts the given date to the number of nanoseconds since January 1st, 1970 UTC
      */
-    public static BigDecimal to_epoch(EvaluationContext ctx, Object datetime) {
+    public static BigDecimal epoch(EvaluationContext ctx, Object datetime) {
         Instant instant = Conversions.toDateTime(datetime, ctx).toInstant();
-        return new BigDecimal(instant.getEpochSecond() * 1000000000 + instant.getNano());
+        BigDecimal nanos = new BigDecimal(instant.getEpochSecond() * 1000000000 + instant.getNano());
+        return nanos.divide(new BigDecimal(1000000000));
     }
 
     /**

--- a/java/src/main/java/io/rapidpro/expressions/functions/CustomFunctions.java
+++ b/java/src/main/java/io/rapidpro/expressions/functions/CustomFunctions.java
@@ -58,6 +58,14 @@ public class CustomFunctions {
     }
 
     /**
+     * Converts the given date to the number of nanoseconds since January 1st, 1970 UTC
+     */
+    public static BigDecimal to_epoch(EvaluationContext ctx, Object datetime) {
+        Instant instant = Conversions.toDateTime(datetime, ctx).toInstant();
+        return new BigDecimal(instant.getEpochSecond() * 1000000000 + instant.getNano());
+    }
+
+    /**
      * Formats digits in text for reading in TTS
      */
     public static String read_digits(EvaluationContext ctx, Object text) {

--- a/java/src/main/java/io/rapidpro/expressions/utils/ExpressionUtils.java
+++ b/java/src/main/java/io/rapidpro/expressions/utils/ExpressionUtils.java
@@ -11,6 +11,7 @@ import org.threeten.bp.format.DateTimeFormatter;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.math.RoundingMode;
 import java.net.URLEncoder;
 import java.util.*;
@@ -26,6 +27,11 @@ public final class ExpressionUtils {
     protected static DateTimeFormatter ISO_DATETIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSxxx");
     protected static DateTimeFormatter ISO_DATETIME_FORMAT_NO_SECOND_FRACTION = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssxxx");
     protected static DateTimeFormatter JSON_DATETIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+
+    /**
+     * A math context which match the defaults of Python's Decimal
+     */
+    public static MathContext MATH = new MathContext(28, RoundingMode.HALF_EVEN);
 
     /**
      * Slices a list, Python style
@@ -63,7 +69,7 @@ public final class ExpressionUtils {
      * Pow for two decimals
      */
     public static BigDecimal decimalPow(BigDecimal number, BigDecimal power) {
-        return new BigDecimal(Math.pow(number.doubleValue(), power.doubleValue()));
+        return new BigDecimal(Math.pow(number.doubleValue(), power.doubleValue()), MATH);
     }
 
     /**

--- a/java/src/test/java/io/rapidpro/expressions/evaluator/ConversionsTest.java
+++ b/java/src/test/java/io/rapidpro/expressions/evaluator/ConversionsTest.java
@@ -102,10 +102,12 @@ public class ConversionsTest {
         assertThat(Conversions.toString(-1, m_context), is("-1"));
         assertThat(Conversions.toString(1234567890, m_context), is("1234567890"));
 
+        assertThat(Conversions.toString(new BigDecimal("2.0"), m_context), is("2"));
+        assertThat(Conversions.toString(new BigDecimal("1234000"), m_context), is("1234000"));
         assertThat(Conversions.toString(new BigDecimal("0.4440000"), m_context), is("0.444"));
-        assertThat(Conversions.toString(new BigDecimal("1234567890.5"), m_context), is("1234567891"));
-        assertThat(Conversions.toString(new BigDecimal("33.333333333333"), m_context), is("33.33333333"));
-        assertThat(Conversions.toString(new BigDecimal("66.666666666666"), m_context), is("66.66666667"));
+        assertThat(Conversions.toString(new BigDecimal("1234567890.50"), m_context), is("1234567890.5"));
+        assertThat(Conversions.toString(new BigDecimal("33.333333333333"), m_context), is("33.333333333333"));
+        assertThat(Conversions.toString(new BigDecimal("66.666666666666"), m_context), is("66.666666666666"));
 
         assertThat(Conversions.toString("hello", m_context), is("hello"));
 

--- a/java/src/test/java/io/rapidpro/expressions/evaluator/EvaluatorTest.java
+++ b/java/src/test/java/io/rapidpro/expressions/evaluator/EvaluatorTest.java
@@ -66,7 +66,7 @@ public class EvaluatorTest {
         assertThat(m_evaluator.evaluateExpression("1.3 + 2.2", context), is((Object) new BigDecimal("3.5")));
         assertThat(m_evaluator.evaluateExpression("1.3 - 2.2", context), is((Object) new BigDecimal("-0.9")));
         assertThat(m_evaluator.evaluateExpression("4 * 2", context), is((Object) new BigDecimal(8)));
-        assertThat(m_evaluator.evaluateExpression("4 / 2", context), is((Object) new BigDecimal("2.0000000000")));
+        assertThat(m_evaluator.evaluateExpression("4 / 2", context), is((Object) new BigDecimal("2")));
         assertThat(m_evaluator.evaluateExpression("4 ^ 2", context), is((Object) new BigDecimal(16)));
         assertThat(m_evaluator.evaluateExpression("4 ^ 0.5", context), is((Object) new BigDecimal(2)));
         assertThat(m_evaluator.evaluateExpression("4 ^ -1", context), is((Object) new BigDecimal("0.25")));
@@ -75,7 +75,7 @@ public class EvaluatorTest {
         assertThat(m_evaluator.evaluateExpression("2 & 3 & 4", context), is((Object) "234"));
 
         // check precedence
-        assertThat(m_evaluator.evaluateExpression("2 + 3 / 4 - 5 * 6", context), is((Object) new BigDecimal("-27.2500000000")));
+        assertThat(m_evaluator.evaluateExpression("2 + 3 / 4 - 5 * 6", context), is((Object) new BigDecimal("-27.25")));
         assertThat(m_evaluator.evaluateExpression("2 & 3 + 4 & 5", context), is((Object) "275"));
 
         // check associativity

--- a/java/src/test/java/io/rapidpro/expressions/functions/ExcelFunctionsTest.java
+++ b/java/src/test/java/io/rapidpro/expressions/functions/ExcelFunctionsTest.java
@@ -305,8 +305,8 @@ public class ExcelFunctionsTest {
 
     @Test
     public void test_exp() {
-        assertThat(exp(m_context, 1), is(new BigDecimal("2.718281828459045090795598298427648842334747314453125")));
-        assertThat(exp(m_context, "2.0"), is(new BigDecimal("7.38905609893064951876340273884125053882598876953125")));
+        assertThat(exp(m_context, 1), is(new BigDecimal("2.718281828459045090795598298")));
+        assertThat(exp(m_context, "2.0"), is(new BigDecimal("7.389056098930649518763402739")));
     }
 
     @Test

--- a/python/temba_expressions/conversions.py
+++ b/python/temba_expressions/conversions.py
@@ -1,6 +1,6 @@
 import datetime
 
-from decimal import Decimal, getcontext, ROUND_HALF_UP
+from decimal import Decimal, ROUND_HALF_UP
 from . import EvaluationError
 
 
@@ -199,22 +199,14 @@ def to_repr(value, ctx):
 
 def format_decimal(decimal):
     """
-    Formats a decimal number using the same precision as Excel
+    Formats a decimal number
     :param decimal: the decimal value
     :return: the formatted string value
     """
-    getcontext().rounding = ROUND_HALF_UP
-
-    # strip trailing zeros
+    # strip trailing fractional zeros
     normalized = decimal.normalize()
     sign, digits, exponent = normalized.as_tuple()
     if exponent >= 1:
         normalized = normalized.quantize(1)
-        sign, digits, exponent = normalized.as_tuple()
-
-    int_digits = len(digits) + exponent
-    fractional_digits = min(max(10 - int_digits, 0), -exponent)
-
-    normalized = normalized.quantize(Decimal(10) ** -fractional_digits)
 
     return str(normalized)

--- a/python/temba_expressions/functions/custom.py
+++ b/python/temba_expressions/functions/custom.py
@@ -41,6 +41,13 @@ def percent(ctx, number):
     return '%d%%' % int(round(conversions.to_decimal(number, ctx) * 100))
 
 
+def to_epoch(ctx, datetime):
+    """
+    Converts the given date to the number of nanoseconds since January 1st, 1970 UTC
+    """
+    return int(conversions.to_datetime(datetime, ctx).timestamp() * 1000000000)
+
+
 def read_digits(ctx, text):
     """
     Formats digits in text for reading in TTS

--- a/python/temba_expressions/functions/custom.py
+++ b/python/temba_expressions/functions/custom.py
@@ -1,6 +1,8 @@
 import operator
 import regex
 
+from decimal import Decimal
+
 from temba_expressions import conversions
 from temba_expressions.utils import tokenize
 
@@ -39,11 +41,11 @@ def percent(ctx, number):
     return '%d%%' % int(round(conversions.to_decimal(number, ctx) * 100))
 
 
-def to_epoch(ctx, datetime):
+def epoch(ctx, datetime):
     """
-    Converts the given date to the number of nanoseconds since January 1st, 1970 UTC
+    Converts the given date to the number of seconds since January 1st, 1970 UTC
     """
-    return int(conversions.to_datetime(datetime, ctx).timestamp() * 1000000000)
+    return conversions.to_decimal(str(conversions.to_datetime(datetime, ctx).timestamp()), ctx)
 
 
 def read_digits(ctx, text):

--- a/python/temba_expressions/tests.py
+++ b/python/temba_expressions/tests.py
@@ -163,10 +163,12 @@ class ConversionsTest(unittest.TestCase):
         self.assertEqual(conversions.to_string(-1, self.context), "-1")
         self.assertEqual(conversions.to_string(1234567890, self.context), "1234567890")
 
+        self.assertEqual(conversions.to_string(Decimal("2.0"), self.context), "2")
+        self.assertEqual(conversions.to_string(Decimal("1234000"), self.context), "1234000")
         self.assertEqual(conversions.to_string(Decimal("0.4440000"), self.context), "0.444")
-        self.assertEqual(conversions.to_string(Decimal("1234567890.5"), self.context), "1234567891")
-        self.assertEqual(conversions.to_string(Decimal("33.333333333333"), self.context), "33.33333333")
-        self.assertEqual(conversions.to_string(Decimal("66.666666666666"), self.context), "66.66666667")
+        self.assertEqual(conversions.to_string(Decimal("1234567890.50"), self.context), "1234567890.5")
+        self.assertEqual(conversions.to_string(Decimal("33.333333333333"), self.context), "33.333333333333")
+        self.assertEqual(conversions.to_string(Decimal("66.666666666666"), self.context), "66.666666666666")
 
         self.assertEqual(conversions.to_string("hello", self.context), "hello")
 


### PR DESCRIPTION
Have matched new engine functionality here for easy migration

Am wondering tho if it wouldn't be more user friendly to return a decimal number of seconds (nanos make up the fractional part) like how Python 3 `datetime.timestamp()` does it... rather than returning the number of nanos as an integer value. Either way callers are going to have to do some conversion of the result into seconds or millis in most cases.